### PR TITLE
perf: redirect to photo url instead of downloading file

### DIFF
--- a/app/Http/Controllers/AvatarController.php
+++ b/app/Http/Controllers/AvatarController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Services\AvatarService;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Http\RedirectResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class AvatarController extends Controller
@@ -15,7 +15,7 @@ class AvatarController extends Controller
 
     public function getAvatar(string $username): BinaryFileResponse
     {
-        $cacheKey = sprintf('avatar-%s', $username);
+        $cacheKey = sprintf('avatar-file-%s', $username);
         $ttl = 60 * 10;
         Cache::remember(
             $cacheKey,
@@ -25,5 +25,19 @@ class AvatarController extends Controller
 
         $pathToServe = storage_path("app/avatars/$username.png");
         return response()->file($pathToServe);
+    }
+
+    public function redirectToAvatar(string $username): RedirectResponse
+    {
+        $cacheKey = sprintf('avatar-url-%s', $username);
+        $ttl = 60 * 10;
+
+        $url = Cache::remember(
+            $cacheKey,
+            $ttl,
+            fn() => $this->avatarService->fetchAvatarUrl($username)
+        );
+
+        return response()->redirectTo($url);
     }
 }

--- a/app/Services/AvatarService.php
+++ b/app/Services/AvatarService.php
@@ -13,7 +13,7 @@ class AvatarService
 
     }
 
-    public function downloadAvatarImage(string $username): void
+    public function fetchAvatarUrl(string $username): string
     {
         $twitchUserResponse = $this->client->getUsers([$username]);
         $twitchUserJson = $twitchUserResponse->json()['data'][0] ?? null;
@@ -23,8 +23,14 @@ class AvatarService
             throw TwitchException::userNotFound($username);
         }
 
+        return $twitchUserJson['profile_image_url'];
+    }
+
+    public function downloadAvatarImage(string $username): void
+    {
+        $avatarUrl = $this->fetchAvatarUrl($username);
+
         $storagePath = sprintf('avatars/' . $username . '.png');
-        $avatarUrl = $twitchUserJson['profile_image_url'];
         Storage::put($storagePath, file_get_contents($avatarUrl));
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,4 +18,5 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::get('/{avatar}.png', [AvatarController::class, 'getAvatar'])->name('get-avatar');
+Route::get("/{avatar}.png", [AvatarController::class,"redirectToAvatar"])->name("redirect-avatar");
+Route::get("/file/{avatar}.png", [AvatarController::class, "getAvatar"])->name("get-avatar");


### PR DESCRIPTION
**Summary:**

Currently, the main way to display the streamer's avatar is to fetch the current profile photo url from Twitch's API, **download into storage**, and serve the **downloaded file** to the client.

Instead of downloading the file, you could cut out the middleman and just redirect the client to Twitch's CDN, similar to how `github.com/username.png` works.

This should reduce latency and internal resources, as the file doesn't have to be downloaded and sent over again.


**Changes:**
 - Created a new redirect route into AvatarController
 - Moved the main route `twitch-avatar.dev/{avatar}.png` to new redirect route.
 - Created a route `twitch-avatar.dev/file/{avatar}.png` to the old method in case of compatibility issues. (to be used on a client that doesn't support redirects)